### PR TITLE
Fixed non-RFC-compliant request/response patterns

### DIFF
--- a/src/main/java/org/dellroad/msrp/msg/MsrpInputParser.java
+++ b/src/main/java/org/dellroad/msrp/msg/MsrpInputParser.java
@@ -38,8 +38,8 @@ public class MsrpInputParser {
     /** Default maximum number of extension headers ({@value #DEFAULT_MAX_EXTENSION_HEADERS}) */
     public static final int DEFAULT_MAX_EXTENSION_HEADERS = 32;
 
-    private static final Pattern REQUEST_LINE_PATTERN = Pattern.compile("MSRP ([-.+%=\\p{Alnum}]{3,31}) ([A-Z]+)");
-    private static final Pattern RESPONSE_LINE_PATTERN = Pattern.compile("MSRP ([-.+%=\\p{Alnum}]{3,31}) ([0-9]{3})( (.*))?");
+    private static final Pattern REQUEST_LINE_PATTERN = Pattern.compile("MSRP (\\p{Alnum}[-.+%=\\p{Alnum}]{3,31}) ([A-Z]+)");
+    private static final Pattern RESPONSE_LINE_PATTERN = Pattern.compile("MSRP (\\p{Alnum}[-.+%=\\p{Alnum}]{3,31}) ([0-9]{3})( (.*))?");
 
     private static final Header HEADER_EOF = new Header("dummy", "dummy");
 


### PR DESCRIPTION
Hi Archie!

Your patterns are slightly not in line with RFC https://datatracker.ietf.org/doc/html/rfc4975:

![image](https://github.com/archiecobbs/msrp4j/assets/58819729/7404d7fb-4850-46ba-8691-f4a2517da6a1)

You have 1 `ALPHANUM` missing in the beginning of the patterns, which causes compatibility issues on legit MSRP transactions:

![image](https://github.com/archiecobbs/msrp4j/assets/58819729/45e19e66-fd76-4d00-bea6-5b3e71c476ea)

When fixed:

![image](https://github.com/archiecobbs/msrp4j/assets/58819729/ff99f40e-fd0f-4455-ba60-dbc76a12a07d)

